### PR TITLE
Fix NoSuchMethodError with SnakeYAML 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <dependency>  
   <groupId>com.github.CodingAir</groupId>
   <artifactId>CodingAPI</artifactId>  
-  <version>1.67</version>  
+  <version>1.68</version>  
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.CodingAir</groupId>
     <artifactId>CodingAPI</artifactId>
-    <version>1.67</version>
+    <version>1.68</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -42,6 +42,12 @@
             <artifactId>bungeecord-api</artifactId>
             <version>1.16-R0.3</version>
             <classifier>javadoc</classifier>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/de/codingair/codingapi/bungeecord/files/loader/UTFConfiguration.java
+++ b/src/main/java/de/codingair/codingapi/bungeecord/files/loader/UTFConfiguration.java
@@ -7,6 +7,7 @@ import de.codingair.codingapi.server.reflections.IReflection;
 import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
@@ -25,12 +26,13 @@ public class UTFConfiguration extends ConfigurationProvider {
 
     private final ThreadLocal<Yaml> yaml = new ThreadLocal<Yaml>() {
         protected Yaml initialValue() {
-            Representer representer = new Representer() {{
-                this.representers.put(Configuration.class, data -> represent(getSelf((Configuration) data)));
-            }};
             DumperOptions options = new DumperOptions();
             options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-            return new Yaml(new Constructor(), representer, options);
+            Representer representer = new Representer(options) {{
+                this.representers.put(Configuration.class, data -> represent(getSelf((Configuration) data)));
+            }};
+
+            return new Yaml(new Constructor(new LoaderOptions()), representer, options);
         }
     };
 


### PR DESCRIPTION
Fixes: https://github.com/erikzimmermann/WarpSystem-IssueTracker/issues/749

As I have read, the SnakeYAML needed to be bumped to version 2.0 in newer versions
where the constructor of `Representer` and `Constructor` differ from the old version.

Therefore WarpSystem does not start inside Waterfall/BungeeCord 1.20.
I have tested the fix successfully under Waterfall 1.20, 1.19 and 1.16.