### PR TITLE
Fix exception when running command with no arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.CodingAir</groupId>
     <artifactId>CodingAPI</artifactId>
-    <version>1.97</version>
+    <version>1.98</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/de/codingair/codingapi/server/commands/builder/CommandWrapper.java
+++ b/src/main/java/de/codingair/codingapi/server/commands/builder/CommandWrapper.java
@@ -87,7 +87,13 @@ public class CommandWrapper implements Predicate<Object>, Command<Object>, Sugge
     }
 
     public int run(CommandContext<Object> context) {
-        String args = context.getArgument("args", String.class);
+        String args = "";
+
+        try {
+            args = context.getArgument("args", String.class);
+        } catch (IllegalArgumentException ignored) {
+        }
+        
         return this.builder.onCommand(wrapper.getBukkitSender(context.getSource()), builder.getMain(), builder.getName(), args.split(" ")) ? 1 : 0;
     }
 


### PR DESCRIPTION
This addresses a recently introduced bug where running a command with no arguments causes it to throw an exception:

```
[17:11:44] [Server thread/INFO]: BetTD issued server command: /trade
[17:11:44] [Server thread/ERROR]: Command exception: /trade
java.lang.IllegalArgumentException: No such argument 'args' exists on this command
	at com.mojang.brigadier.context.CommandContext.getArgument(CommandContext.java:102) ~[brigadier-1.3.10.jar:?]
	at TradeSystem_v2.6.3_Hotfix-5.jar/de.codingair.tradesystem.lib.codingapi.server.commands.builder.CommandWrapper.run(CommandWrapper.java:90) ~[TradeSystem_v2.6.3_Hotfix-5.jar:?]
	at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73) ~[brigadier-1.3.10.jar:?]
	at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:30) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:13) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.commands.execution.CommandQueueEntry.execute(CommandQueueEntry.java:5) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:105) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.commands.Commands.executeCommandInContext(Commands.java:459) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.commands.Commands.performCommand(Commands.java:365) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.commands.Commands.performCommand(Commands.java:353) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.performUnsignedChatCommand(ServerGamePacketListenerImpl.java:2382) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$15(ServerGamePacketListenerImpl.java:2355) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1485) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:176) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1465) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1459) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:139) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1416) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1424) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1301) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:313) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
	at java.base/java.lang.Thread.run(Unknown Source) ~[?:?]
```

This PR also bumps the version number to v1.98, a similar PR for TradeSystem will be opened soon. Any changes or questions please let me know.