### PR TITLE
Support Mojang year-scheme (26.1.x), bump to 1.101

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.CodingAir</groupId>
     <artifactId>CodingAPI</artifactId>
-    <version>1.100</version>
+    <version>1.101</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -75,6 +75,12 @@
             <version>1.5.25</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>
@@ -94,6 +100,11 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/de/codingair/codingapi/server/specification/Version.java
+++ b/src/main/java/de/codingair/codingapi/server/specification/Version.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 public class Version {
     private static Double version = null;
+    private static String id = null;
     private static String name = null;
     private static String specification = null;
     private static Type type = Type.UNKNOWN;
@@ -26,32 +27,26 @@ public class Version {
                 type = Type.PAPER;
                 name = "Paper";
                 specification = ServerBuildInfo.minecraftVersionName();
-
-                String parts = ServerBuildInfo.minecraftVersionId();
-                String minorVersion = parts.split("\\.")[1];
-                String subVersion = parts.contains(".") ? parts.split("\\.")[2] : "0";
-
-                String newVersion = minorVersion + "." + (Integer.parseInt(subVersion) < 10 ? "0" + subVersion : subVersion);
-
-                version = Double.parseDouble(newVersion);
+                id = ServerBuildInfo.minecraftVersionId();
+                version = parseVersionId(id);
             } else {
-                // version
-                String bukkitVersion = Bukkit.getVersion();
+                String bukkitVersion;
+                try {
+                    bukkitVersion = Bukkit.getVersion();
+                } catch (Exception e) {
+                    // Server not yet bound (e.g. unit tests); leave version null so get() throws later.
+                    return;
+                }
 
-                Pattern p = Pattern.compile("\\(MC: \\d\\.\\d\\d?(\\.\\d\\d?)?");
-                Matcher match = p.matcher(bukkitVersion);
+                // Permissive enough to match both legacy "1.x.y" and year-scheme "YY.D.P".
+                Matcher match = Pattern.compile("\\(MC: (\\d+(?:\\.\\d+)+)").matcher(bukkitVersion);
                 if (match.find()) {
-                    String parts = match.group().substring(7);
-                    String majorVersion = parts.split("\\.")[0];
-                    String subVersion = parts.contains(".") ? parts.split("\\.")[1] : "0";
-
-                    String newVersion = majorVersion + "." + (Integer.parseInt(subVersion) < 10 ? "0" + subVersion : subVersion);
-
-                    version = Double.parseDouble(newVersion);
+                    id = match.group(1);
+                    version = parseVersionId(id);
                 }
 
                 // specification
-                specification = Bukkit.getVersion();
+                specification = bukkitVersion;
 
                 // server type
                 try {
@@ -72,19 +67,36 @@ public class Version {
         }
     }
 
+    /** Parses a Minecraft version id. Encoding is load-bearing: call sites bake cutoffs as numeric literals
+     *  (e.g. {@code atLeast(20.5)}, {@code choose(old, 21.11, new)}). Legacy "1.X.Y" → X.YY; year-scheme
+     *  "YY.D.P" → (year*100+drop).PP, which sorts strictly above any legacy value. Snapshot ids
+     *  ({@code "23w31a"}, etc.) throw {@link NumberFormatException}. */
+    static double parseVersionId(String id) {
+        String[] segs = id.split("\\.");
+        int first = Integer.parseInt(segs[0]);
+
+        if (first == 1) {
+            String minorVersion = segs[1];
+            String subVersion = segs.length > 2 ? segs[2] : "0";
+            String newVersion = minorVersion + "." + (Integer.parseInt(subVersion) < 10 ? "0" + subVersion : subVersion);
+            return Double.parseDouble(newVersion);
+        }
+
+        int year = first;
+        int drop = segs.length > 1 ? Integer.parseInt(segs[1]) : 0;
+        int patch = segs.length > 2 ? Integer.parseInt(segs[2]) : 0;
+        String encoded = (year * 100 + drop) + "." + (patch < 10 ? "0" + patch : Integer.toString(patch));
+        return Double.parseDouble(encoded);
+    }
+
     public static double get() {
         if (version == null) throw new IllegalStateException("Version could not be loaded.");
         return version;
     }
 
-    private static String getRightVersion() {
-        String ver = String.valueOf(version);
-        if(ver.split("\\.")[1].length() == 1) ver += "0";
-        return ver.replace(".0", ".");
-    }
-
     public static String versionTag() {
-        return "1." + getRightVersion();
+        if (id == null) throw new IllegalStateException("Version could not be loaded.");
+        return id;
     }
 
     public static String fullVersion() {
@@ -226,17 +238,27 @@ public class Version {
                 infoClass = null;
             }
 
-            if (infoClass == null) {
-                info = null;
-                minecraftVersionId = null;
-                minecraftVersionName = null;
-            } else {
-                IReflection.MethodAccessor buildInfo = IReflection.getMethod(infoClass, infoClass, new Class[0]);
-                info = buildInfo.invoke(null);
+            Object resolvedInfo = null;
+            IReflection.MethodAccessor resolvedVersionId = null;
+            IReflection.MethodAccessor resolvedVersionName = null;
 
-                minecraftVersionId = IReflection.getMethod(infoClass, "minecraftVersionId", String.class, new Class[0]);
-                minecraftVersionName = IReflection.getMethod(infoClass, "minecraftVersionName", String.class, new Class[0]);
+            if (infoClass != null) {
+                try {
+                    IReflection.MethodAccessor buildInfo = IReflection.getMethod(infoClass, infoClass, new Class[0]);
+                    resolvedInfo = buildInfo.invoke(null);
+                    resolvedVersionId = IReflection.getMethod(infoClass, "minecraftVersionId", String.class, new Class[0]);
+                    resolvedVersionName = IReflection.getMethod(infoClass, "minecraftVersionName", String.class, new Class[0]);
+                } catch (Throwable t) {
+                    // Class visible but no live instance (e.g. ServiceLoader unset in tests); fall through to Bukkit path.
+                    resolvedInfo = null;
+                    resolvedVersionId = null;
+                    resolvedVersionName = null;
+                }
             }
+
+            info = resolvedInfo;
+            minecraftVersionId = resolvedVersionId;
+            minecraftVersionName = resolvedVersionName;
         }
 
         private static boolean isAvailable() {

--- a/src/main/java/de/codingair/codingapi/tools/items/XMaterial.java
+++ b/src/main/java/de/codingair/codingapi/tools/items/XMaterial.java
@@ -2320,9 +2320,11 @@ public enum XMaterial /* implements com.cryptomorin.xseries.abstractions.Materia
 
         static { // This needs to be right below VERSION because of initialization order.
             String version = Bukkit.getVersion();
-            Matcher matcher = Pattern.compile("MC: \\d\\.(\\d+)").matcher(version);
+            Matcher legacy = Pattern.compile("MC: 1\\.(\\d+)").matcher(version);
+            Matcher yearScheme = Pattern.compile("MC: (\\d{2,})\\.").matcher(version);
 
-            if (matcher.find()) VERSION = Integer.parseInt(matcher.group(1));
+            if (legacy.find()) VERSION = Integer.parseInt(legacy.group(1));
+            else if (yearScheme.find()) VERSION = 99; // year-scheme (Mojang 2026+): treat as newest legacy minor
             else throw new IllegalArgumentException("Failed to parse server version from: " + version);
         }
     }

--- a/src/test/java/de/codingair/codingapi/server/specification/VersionTest.java
+++ b/src/test/java/de/codingair/codingapi/server/specification/VersionTest.java
@@ -1,0 +1,104 @@
+package de.codingair.codingapi.server.specification;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VersionTest {
+
+    // ---- Legacy 1.X.Y scheme (must be preserved) ----
+
+    @Test
+    void parsesLegacyVersion_1_21_11() {
+        assertEquals(21.11, Version.parseVersionId("1.21.11"), 0.0001);
+    }
+
+    @Test
+    void parsesLegacyVersion_1_21_4() {
+        assertEquals(21.04, Version.parseVersionId("1.21.4"), 0.0001);
+    }
+
+    @Test
+    void parsesLegacyVersion_withoutPatch_1_8() {
+        // The current regex-fallback path can match "1.8" (no third segment).
+        assertEquals(8.0, Version.parseVersionId("1.8"), 0.0001);
+    }
+
+    @Test
+    void parsesLegacyVersion_1_20_5() {
+        // Boundary: Paper's mojangMapped() check uses 20.5.
+        assertEquals(20.05, Version.parseVersionId("1.20.5"), 0.0001);
+    }
+
+    // ---- New year-based scheme ----
+
+    @Test
+    void parsesYearScheme_26_1_2() {
+        assertEquals(2601.02, Version.parseVersionId("26.1.2"), 0.0001);
+    }
+
+    @Test
+    void parsesYearScheme_26_1_0() {
+        // A hypothetical 26.1.0 (initial drop release before any patch).
+        assertEquals(2601.00, Version.parseVersionId("26.1.0"), 0.0001);
+    }
+
+    @Test
+    void parsesYearScheme_26_1_noPatch() {
+        assertEquals(2601.00, Version.parseVersionId("26.1"), 0.0001);
+    }
+
+    @Test
+    void parsesYearScheme_26_2_0_ordersAbove_26_1_x() {
+        // Pin exact encoded values, not just ordering — many wrong encodings would also satisfy ordering.
+        assertEquals(2601.02, Version.parseVersionId("26.1.2"), 0.0001);
+        assertEquals(2602.00, Version.parseVersionId("26.2.0"), 0.0001);
+        assertTrue(Version.parseVersionId("26.2.0") > Version.parseVersionId("26.1.2"),
+            "26.2.0 must order strictly above 26.1.2");
+    }
+
+    @Test
+    void parsesYearScheme_26_10_0_doesNotCollideWith_27_0_0() {
+        // Drop ≥ 10 within a single year must still sort below the next year's first drop.
+        assertTrue(Version.parseVersionId("27.0.0") > Version.parseVersionId("26.10.0"),
+            "27.0.0 must order strictly above 26.10.0 (no encoding collision)");
+    }
+
+    @Test
+    void parsesYearScheme_27_1_0_ordersAbove_26_x() {
+        double v26_2_0 = Version.parseVersionId("26.2.0");
+        double v27_1_0 = Version.parseVersionId("27.1.0");
+        assertTrue(v27_1_0 > v26_2_0, "27.1.0 must order strictly above 26.2.0");
+    }
+
+    // ---- Cross-scheme ordering (year-scheme must always exceed any legacy) ----
+
+    @Test
+    void yearScheme_alwaysAboveAnyLegacyVersion() {
+        double maxLegacyLike = Version.parseVersionId("1.99.99"); // synthetic ceiling
+        double minYearScheme = Version.parseVersionId("26.1.0");
+        assertTrue(minYearScheme > maxLegacyLike,
+            "Year-scheme floor (26.1.0=" + minYearScheme + ") must exceed legacy ceiling (1.99.99=" + maxLegacyLike + ")");
+    }
+
+    @Test
+    void yearScheme_26_1_2_clearsLegacyCallSiteCutoffs() {
+        // mojangMapped() requires atLeast(20.5); many Version.choose() sites switched at 21.11.
+        // Year-scheme values must clear both cutoffs for the dispatch to land on modern branches.
+        double encoded = Version.parseVersionId("26.1.2");
+        assertTrue(encoded >= 20.5,
+            "26.1.2 must satisfy the mojangMapped() atLeast(20.5) threshold (got " + encoded + ")");
+        assertTrue(encoded >= 21.11,
+            "26.1.2 must satisfy the 21.11 cutoff used in many Version.choose() calls (got " + encoded + ")");
+    }
+
+    // ---- Snapshot / pre-release inputs (documented to throw) ----
+
+    @Test
+    void parsesSnapshotId_throwsNumberFormatException() {
+        // Pin javadoc'd contract: snapshot ids fail loudly rather than encode to surprising values.
+        assertThrows(NumberFormatException.class, () -> Version.parseVersionId("23w31a"));
+    }
+}


### PR DESCRIPTION
Paper 26.1.2 broke two parsers at plugin enable. Version.load() encoded "26.1.2" as 1.02, so atLeast(20.5) and the 21.11 NMS cutoff both failed and reflection crashed. XMaterial's regex required a single digit before the first dot and threw at static init.

Year-scheme now encodes as year*100+drop (26.1.2 -> 2601.02), sorts above any legacy 1.x, collision-free up to drop 99. Bukkit-fallback regex broadened to match both schemes. Raw id stored so versionTag() returns "26.1.2" instead of the garbled "1.261.2" that was showing up in NMS error logs.