### PR TITLE
Fix AnvilGUI ContainerAccess lookup on 21.11+, bump to 1.102

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.CodingAir</groupId>
     <artifactId>CodingAPI</artifactId>
-    <version>1.101</version>
+    <version>1.102</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/de/codingair/codingapi/player/gui/anvil/AnvilGUI.java
+++ b/src/main/java/de/codingair/codingapi/player/gui/anvil/AnvilGUI.java
@@ -268,7 +268,7 @@ public class AnvilGUI implements Removable {
 
         Object container;
         if (Version.atLeast(14)) {
-            Class<?> containerAccessClass = IReflection.getClass(IReflection.ServerPacket.INVENTORY, "ContainerAccess");
+            Class<?> containerAccessClass = IReflection.getClass(IReflection.ServerPacket.INVENTORY, Version.choose("ContainerAccess", 21.11, "ContainerLevelAccess"));
             IReflection.MethodAccessor at = IReflection.getMethod(containerAccessClass, containerAccessClass, new Class[]{WORLD_CLASS, BLOCK_POSITION_CLASS});
 
             Object containerAccess = at.invoke(null, world, blockPosition);


### PR DESCRIPTION
The 1.21.11 commit (d5369ab) gated the static-init lookup behind Version.choose but missed the duplicate lookup inside AnvilGUI.open(), which still resolves the pre-21.11 name. Every anvil GUI open then throws ClassNotFoundException for net.minecraft.world.inventory.ContainerAccess on Paper 1.21.11+/26.x.